### PR TITLE
Fix code scanning alert no. 10: Uncontrolled command line

### DIFF
--- a/vuln_server/vulnerabilities/subprocess_vuln.py
+++ b/vuln_server/vulnerabilities/subprocess_vuln.py
@@ -16,8 +16,13 @@ class SubprocessVuln():
                     output = OutputGrabber()
                     with output:
                         # Execute system command with an unsafe input parameter
-                        subprocess.call("ping -c1 " +
-                                        request.form['input_data'], shell=True)
+                        # Define an allowlist of acceptable inputs
+                        ALLOWLIST = {'localhost', '127.0.0.1'}
+                        input_data = request.form['input_data']
+                        if input_data in ALLOWLIST:
+                            subprocess.call(["ping", "-c1", input_data])
+                        else:
+                            return "Invalid input"
                     return output.capturedtext
                 except Exception as e:
                     return "Server Error: {}:".format(str(e))


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Python_2/security/code-scanning/10](https://github.com/digiALERT1/Python_2/security/code-scanning/10)

To fix the problem, we should avoid directly using user input in the command string. Instead, we can use a predefined allowlist of acceptable inputs and validate the user input against this allowlist. If the input is valid, we can safely construct the command. This approach ensures that only known, safe commands are executed.

1. Define an allowlist of acceptable inputs.
2. Validate the user input against this allowlist.
3. Construct the command using the validated input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
