### PR TITLE
Fix code scanning alert no. 8: Deserialization of user-controlled data

### DIFF
--- a/vuln_server/vulnerabilities/yaml_vuln.py
+++ b/vuln_server/vulnerabilities/yaml_vuln.py
@@ -16,8 +16,7 @@ class YAMLVuln():
                     with output:
                         # Load unsafe YAML input, output from the exploit
                         # is stored into Outputgrabber stdout
-                        yaml.load(request.form['input_data'],
-                                  Loader=yaml.UnsafeLoader)
+                        yaml.safe_load(request.form['input_data'])
                     return output.capturedtext
                 except Exception as e:
                     return "Server Error: {}:".format(str(e))


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Python_2/security/code-scanning/8](https://github.com/digiALERT1/Python_2/security/code-scanning/8)

To fix the problem, we should replace the unsafe `yaml.load` function with `yaml.safe_load`, which is designed to safely parse YAML input without allowing the construction of arbitrary objects. This change will prevent the execution of potentially malicious code embedded in the YAML input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
