### PR TITLE
Fix code scanning alert no. 7: Deserialization of user-controlled data

### DIFF
--- a/vuln_server/vulnerabilities/pickle_vuln.py
+++ b/vuln_server/vulnerabilities/pickle_vuln.py
@@ -1,5 +1,5 @@
 import base64
-import pickle
+import json
 from vuln_server.outputgrabber import OutputGrabber
 from flask import flash, request, redirect, render_template
 
@@ -22,8 +22,8 @@ class PickleVuln():
                     with output:
                         # Load base64 encoded pickle object, output from the
                         # exploit is stored into Outputgrabber stdout
-                        pickle.loads(
-                            base64.b64decode(request.form['input_data']))
+                        json.loads(
+                            base64.b64decode(request.form['input_data']).decode('utf-8'))
                     return output.capturedtext
                 except Exception as e:
                     return "Server Error: {}:".format(str(e))
@@ -32,7 +32,7 @@ class PickleVuln():
                 try:
                     output = OutputGrabber()
                     with output:
-                        pickle.loads(base64.b64decode(file_data.decode()))
+                        json.loads(base64.b64decode(file_data.decode()).decode('utf-8'))
                     return output.capturedtext
                 except Exception as e:
                     return "Server Error: {}:".format(str(e))


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Python_2/security/code-scanning/7](https://github.com/digiALERT1/Python_2/security/code-scanning/7)

To fix the problem, we should avoid using `pickle.loads` to deserialize user-provided data. Instead, we can use a safer alternative such as `json.loads`, which does not allow arbitrary code execution. This change will ensure that the deserialization process is secure while maintaining the existing functionality.

1. Replace `pickle.loads` with `json.loads`.
2. Ensure that the data being deserialized is in a JSON-compatible format.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
