### PR TITLE
Fix code scanning alert no. 9: XML internal entity expansion

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 Flask==1.1.1
 PyYAML
+
+defusedxml==0.7.1

--- a/vuln_server/vulnerabilities/xml_vuln.py
+++ b/vuln_server/vulnerabilities/xml_vuln.py
@@ -1,6 +1,5 @@
-from xml.dom.pulldom import parseString
-from xml.sax import make_parser
-from xml.sax.handler import feature_external_ges
+from defusedxml.pulldom import parseString
+
 
 from flask import request, redirect, render_template
 
@@ -14,9 +13,7 @@ class XMLVuln():
             if request.form['input_data'] != '':
                 # Instanciate an XML parser allowing unsafe external
                 # sources to to be parsed by xml.parseString
-                parser = make_parser()
-                parser.setFeature(feature_external_ges, True)
-                doc = parseString(request.form['input_data'], parser=parser)
+                doc = parseString(request.form['input_data'])
                 for event, node in doc:
                     doc.expandNode(node)
                     return(node.toxml())


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Python_2/security/code-scanning/9](https://github.com/digiALERT1/Python_2/security/code-scanning/9)

To fix the problem, we should replace the current XML parsing approach with a safer alternative that prevents XML bomb attacks. The `defusedxml` library is designed to handle such cases securely. We will use `defusedxml.pulldom.parseString` instead of `xml.dom.pulldom.parseString` and remove the configuration that allows external entity expansion.

- Replace the import of `xml.dom.pulldom.parseString` with `defusedxml.pulldom.parseString`.
- Remove the `make_parser` and `setFeature` calls, as `defusedxml` handles these security concerns internally.
- Ensure the rest of the functionality remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
