### PR TITLE
Fix code scanning alert no. 16: Information exposure through an exception

### DIFF
--- a/vuln_server/vulnerabilities/subprocess_vuln.py
+++ b/vuln_server/vulnerabilities/subprocess_vuln.py
@@ -1,7 +1,7 @@
 import subprocess
 
 from vuln_server.outputgrabber import OutputGrabber
-from flask import request, redirect, render_template
+from flask import request, redirect, render_template, current_app as app
 
 
 class SubprocessVuln():
@@ -20,7 +20,8 @@ class SubprocessVuln():
                                         request.form['input_data'], shell=True)
                     return output.capturedtext
                 except Exception as e:
-                    return "Server Error: {}:".format(str(e))
+                    app.logger.error("Exception occurred", exc_info=True)
+                    return "An internal error has occurred!"
             else:
                 return redirect(request.url)
         return render_template('subprocess.html')


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Python_2/security/code-scanning/16](https://github.com/digiALERT1/Python_2/security/code-scanning/16)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the user. Instead, we should log the detailed exception information on the server and return a generic error message to the user. This approach maintains the ability to debug issues while protecting sensitive information from being exposed.

1. Modify the exception handling in the `bypass` method of `SubprocessVuln` class to log the detailed exception message and return a generic error message to the user.
2. Add necessary imports for logging.
3. Ensure that the logging configuration is set up to capture and store the logs appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
