### PR TITLE
Fix code scanning alert no. 15: Information exposure through an exception

### DIFF
--- a/vuln_server/vulnerabilities/eval_vuln.py
+++ b/vuln_server/vulnerabilities/eval_vuln.py
@@ -21,7 +21,9 @@ class EvalVuln():
                             pass
                     return output.capturedtext
                 except Exception as e:
-                    return "Server Error: {}:".format(str(e))
+                    import logging
+                    logging.error("Exception occurred", exc_info=True)
+                    return "An internal error has occurred!"
             else:
                 return redirect(request.url)
         return render_template('eval.html')


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Python_2/security/code-scanning/15](https://github.com/digiALERT1/Python_2/security/code-scanning/15)

To fix the problem, we need to ensure that detailed error messages and stack traces are not exposed to the end user. Instead, we should log the error details on the server and return a generic error message to the user. This can be achieved by modifying the exception handling in the `bypass` method of the `EvalVuln` class.

1. Import the `logging` module to log the error details.
2. Replace the return statement in the exception block to log the error and return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
