### PR TITLE
Fix code scanning alert no. 14: Information exposure through an exception

### DIFF
--- a/vuln_server/vulnerabilities/yaml_vuln.py
+++ b/vuln_server/vulnerabilities/yaml_vuln.py
@@ -20,7 +20,8 @@ class YAMLVuln():
                                   Loader=yaml.UnsafeLoader)
                     return output.capturedtext
                 except Exception as e:
-                    return "Server Error: {}:".format(str(e))
+                    app.logger.error("Exception occurred", exc_info=True)
+                    return "An internal error has occurred!"
             else:
                 return redirect(request.url)
         return render_template('yaml.html')


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Python_2/security/code-scanning/14](https://github.com/digiALERT1/Python_2/security/code-scanning/14)

To fix the problem, we need to ensure that detailed error messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the `injection` method in `YAMLVuln` to log the exception and return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
