### PR TITLE
Fix code scanning alert no. 13: Information exposure through an exception

### DIFF
--- a/vuln_server/vulnerabilities/pickle_vuln.py
+++ b/vuln_server/vulnerabilities/pickle_vuln.py
@@ -2,7 +2,10 @@ import base64
 import pickle
 from vuln_server.outputgrabber import OutputGrabber
 from flask import flash, request, redirect, render_template
+import logging
 
+
+logging.basicConfig(level=logging.ERROR)
 
 class PickleVuln():
 
@@ -26,7 +29,8 @@ class PickleVuln():
                             base64.b64decode(request.form['input_data']))
                     return output.capturedtext
                 except Exception as e:
-                    return "Server Error: {}:".format(str(e))
+                    logging.error("Exception occurred", exc_info=True)
+                    return "An internal error has occurred!"
             elif request.files['file'].filename != '':
                 file_data = request.files['file'].read()
                 try:
@@ -35,7 +39,8 @@ class PickleVuln():
                         pickle.loads(base64.b64decode(file_data.decode()))
                     return output.capturedtext
                 except Exception as e:
-                    return "Server Error: {}:".format(str(e))
+                    logging.error("Exception occurred", exc_info=True)
+                    return "An internal error has occurred!"
             else:
                 flash('No selected file')
                 return redirect(request.url)


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Python_2/security/code-scanning/13](https://github.com/digiALERT1/Python_2/security/code-scanning/13)

To fix the problem, we need to ensure that detailed exception messages and stack traces are not exposed to the end user. Instead, we should log the detailed error information on the server and return a generic error message to the user. This can be achieved by modifying the `injection` method in the `PickleVuln` class to log the exception details and return a generic error message.

We will:
1. Import the `logging` module to log the exception details.
2. Configure the logging settings if not already configured.
3. Modify the `injection` method to log the exception details and return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
