### PR TITLE
Fix code scanning alert no. 4: URL redirection from remote source

### DIFF
--- a/vuln_server/vulnerabilities/xml_vuln.py
+++ b/vuln_server/vulnerabilities/xml_vuln.py
@@ -3,6 +3,7 @@ from xml.sax import make_parser
 from xml.sax.handler import feature_external_ges
 
 from flask import request, redirect, render_template
+from urllib.parse import urlparse
 
 
 class XMLVuln():
@@ -21,5 +22,8 @@ class XMLVuln():
                     doc.expandNode(node)
                     return(node.toxml())
             else:
-                return redirect(request.url)
+                target_url = request.url.replace('\\', '')
+                if not urlparse(target_url).netloc and not urlparse(target_url).scheme:
+                    return redirect(target_url)
+                return redirect('/')
         return render_template('xml.html')


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Python_2/security/code-scanning/4](https://github.com/digiALERT1/Python_2/security/code-scanning/4)

To fix the problem, we need to validate the URL before using it in a redirect. One way to do this is to ensure that the URL does not contain an explicit host name, which can be done using the `urlparse` function from the Python standard library. We should also handle backslashes and mistyped URLs as described in the background section.

- Import the `urlparse` function from the `urllib.parse` module.
- Replace the direct use of `request.url` with a validated version.
- Ensure that the URL does not contain an explicit host name and is a relative path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
