### PR TITLE
Fix code scanning alert no. 3: URL redirection from remote source

### DIFF
--- a/vuln_server/vulnerabilities/subprocess_vuln.py
+++ b/vuln_server/vulnerabilities/subprocess_vuln.py
@@ -2,6 +2,7 @@ import subprocess
 
 from vuln_server.outputgrabber import OutputGrabber
 from flask import request, redirect, render_template
+from urllib.parse import urlparse
 
 
 class SubprocessVuln():
@@ -22,5 +23,8 @@ class SubprocessVuln():
                 except Exception as e:
                     return "Server Error: {}:".format(str(e))
             else:
-                return redirect(request.url)
+                target_url = request.url.replace('\\', '')
+                if not urlparse(target_url).netloc and not urlparse(target_url).scheme:
+                    return redirect(target_url)
+                return redirect('/')
         return render_template('subprocess.html')


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Python_2/security/code-scanning/3](https://github.com/digiALERT1/Python_2/security/code-scanning/3)

To fix the problem, we need to validate the `request.url` before using it in a redirect. One way to do this is to ensure that the URL does not contain an explicit host name, which can be done using the `urlparse` function from the Python standard library. We should also handle backslashes and mistyped URLs to ensure they are parsed correctly.

The best way to fix the problem without changing existing functionality is to replace the direct use of `request.url` with a validated version of the URL. This involves parsing the URL and checking that it does not specify an explicit host name.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
