### PR TITLE
Fix code scanning alert no. 2: URL redirection from remote source

### DIFF
--- a/vuln_server/vulnerabilities/pickle_vuln.py
+++ b/vuln_server/vulnerabilities/pickle_vuln.py
@@ -2,6 +2,7 @@ import base64
 import pickle
 from vuln_server.outputgrabber import OutputGrabber
 from flask import flash, request, redirect, render_template
+from urllib.parse import urlparse
 
 
 class PickleVuln():
@@ -38,5 +39,9 @@ class PickleVuln():
                     return "Server Error: {}:".format(str(e))
             else:
                 flash('No selected file')
-                return redirect(request.url)
+                target_url = request.url.replace('\\', '/')
+                parsed_url = urlparse(target_url)
+                if not parsed_url.netloc and not parsed_url.scheme:
+                    return redirect(target_url)
+                return redirect('/')
         return render_template('pickle.html')


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Python_2/security/code-scanning/2](https://github.com/digiALERT1/Python_2/security/code-scanning/2)

To fix the problem, we need to ensure that the URL used in the redirect is validated before it is used. One way to do this is to check that the URL does not include an explicit host name, ensuring it is a relative path. This can be done using the `urlparse` function from the Python standard library. We will replace backslashes with forward slashes and check that both the `netloc` and `scheme` attributes of the parsed URL are empty.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
