### PR TITLE
Fix code scanning alert no. 1: URL redirection from remote source

### DIFF
--- a/vuln_server/vulnerabilities/eval_vuln.py
+++ b/vuln_server/vulnerabilities/eval_vuln.py
@@ -2,6 +2,7 @@ import random
 
 from vuln_server.outputgrabber import OutputGrabber
 from flask import request, redirect, render_template
+from urllib.parse import urlparse
 
 
 class EvalVuln():
@@ -23,5 +24,8 @@ class EvalVuln():
                 except Exception as e:
                     return "Server Error: {}:".format(str(e))
             else:
-                return redirect(request.url)
+                target_url = request.url.replace('\\', '')
+                if not urlparse(target_url).netloc and not urlparse(target_url).scheme:
+                    return redirect(target_url)
+                return redirect('/')
         return render_template('eval.html')


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Python_2/security/code-scanning/1](https://github.com/digiALERT1/Python_2/security/code-scanning/1)

To fix the problem, we need to ensure that the URL used in the redirect is validated to prevent open redirect vulnerabilities. One way to do this is to check that the URL does not include an explicit host name, ensuring it is a relative path. We can use the `urlparse` function from the Python standard library to parse the URL and check that the `netloc` attribute is empty.

We will modify the code in the `bypass` method to validate the `request.url` before using it in the redirect. If the URL is not valid, we will redirect to a safe default URL (e.g., the home page).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
